### PR TITLE
Use /usr/bin/env to find bash, as this is best practice.

### DIFF
--- a/notify/onScriptComplete.sh
+++ b/notify/onScriptComplete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ./onScriptComplete [mail]
 
 logFile="`dirname $0`/log.log"

--- a/notify/onScriptFailure.sh
+++ b/notify/onScriptFailure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ./onScriptFailure [mail] "error message"
 
 logFile="`dirname $0`/log.log"


### PR DESCRIPTION
Not all systems and distros place bash in /bin/. It is a common
"best practice" to use /usr/bin/env around the call to bash to search
all PATHs for it, and avoid compatibility issues across systems.