### PR TITLE
Correct top-level domain for wikipedia generator

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,8 +32,8 @@ from helpers import BingAccountError
 verbose = False
 totalPoints = 0
 
-SCRIPT_VERSION = "3.10.0"
-SCRIPT_DATE = "June 12, 2015"
+SCRIPT_VERSION = "3.10.1"
+SCRIPT_DATE = "June 14, 2015"
 
 def earnRewards(config, httpHeaders, userAgents, reportItem, password):
     """Earns Bing! reward points and populates reportItem"""

--- a/pkg/queryGenerators/wikipedia.py
+++ b/pkg/queryGenerators/wikipedia.py
@@ -13,7 +13,7 @@ from datetime import date
 from bingRewards import BingRewards
 
 month_names = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
-QUERY_URL = "http://en.wikipedia.com/wiki/{0}_{1}".format(month_names[date.today().month - 1], date.today().strftime("%d"))
+QUERY_URL = "http://en.wikipedia.org/wiki/{0}_{1}".format(month_names[date.today().month - 1], date.today().strftime("%d"))
 
 class queryGenerator:
     def __init__(self, br):

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,7 @@
 Current version 3.10.0
 
+3.10.1  +) @peterdimou, Fix wikipedia generator top-level domain
+
 3.10.0  +) @amayer, Add Auth Check For Terms Of Use Update
 
 3.9.1   *) Add Check To See If Any Search Results Were Returned Before Clicking


### PR DESCRIPTION
I was getting some SSL errors pointing to a mismatch in hostnames. Changing the top-level domain to 'org' from 'com' should fix this.

EDIT: Including a full stacktrace for reference

```
File "bin/main.py", line 300, in <module>
    EventsProcessor.onScriptFailure(config, e)
  File "bin/main.py", line 298, in <module>
    __run(config)
  File "bin/main.py", line 223, in __run
    reportItem = __processAccountUserAgent(config, account, bingCommon.USER_AGENTS_PC, doSleep)
  File "bin/main.py", line 210, in __processAccountUserAgent
    __processAccount(config, httpHeaders, agents, reportItem, account.password)
  File "bin/main.py", line 183, in __processAccount
    earnRewards(config, httpHeaders, userAgents, reportItem, accountPassword)
  File "bin/main.py", line 60, in earnRewards
    results = bingRewards.process(rewards, verbose)
  File "bin/pkg/bingRewards.py", line 399, in process
    res = self.__processSearch(r, verbose)
  File "bin/pkg/bingRewards.py", line 283, in __processSearch
    queries = queryGenerator.generateQueries(searchesCount, history)
  File "bin/pkg/queryGenerators/wikipedia.py", line 44, in generateQueries
    with self.bingRewards.opener.open(request) as response:
  File "/usr/lib/python2.7/urllib2.py", line 437, in open
    response = meth(req, response)
  File "/usr/lib/python2.7/urllib2.py", line 550, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python2.7/urllib2.py", line 469, in error
    result = self._call_chain(*args)
  File "/usr/lib/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "bin/pkg/bingRewards.py", line 33, in http_error_302
    return urllib2.HTTPRedirectHandler.http_error_302(self, req, fp, code, msg, headers)
  File "/usr/lib/python2.7/urllib2.py", line 656, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/usr/lib/python2.7/urllib2.py", line 431, in open
    response = self._open(req, data)
  File "/usr/lib/python2.7/urllib2.py", line 449, in _open
    '_open', req)
  File "/usr/lib/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 1240, in https_open
    context=self._context)
  File "/usr/lib/python2.7/urllib2.py", line 1194, in do_open
    h.request(req.get_method(), req.get_selector(), req.data, headers)
  File "/usr/lib/python2.7/httplib.py", line 1048, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python2.7/httplib.py", line 1088, in _send_request
    self.endheaders(body)
  File "/usr/lib/python2.7/httplib.py", line 1044, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 888, in _send_output
    self.send(msg)
  File "/usr/lib/python2.7/httplib.py", line 850, in send
    self.connect()
  File "/usr/lib/python2.7/httplib.py", line 1269, in connect
    server_hostname=server_hostname)
  File "/usr/lib/python2.7/ssl.py", line 352, in wrap_socket
    _context=self)
  File "/usr/lib/python2.7/ssl.py", line 579, in __init__
    self.do_handshake()
  File "/usr/lib/python2.7/ssl.py", line 816, in do_handshake
    match_hostname(self.getpeercert(), self.server_hostname)
  File "/usr/lib/python2.7/ssl.py", line 271, in match_hostname
    % (hostname, ', '.join(map(repr, dnsnames))))
ssl.CertificateError: hostname 'en.wikipedia.com' doesn't match either of '*.wikipedia.org', '*.mediawiki.org', '*.wikibooks.org', '*.wikidata.org', '*.wikimedia.org', '*.wikimediafoundation.org', '*.wikinews.org', '*.wikiquote.org', '*.wikisource.org', '*.wikiversity.org', '*.wikivoyage.org', '*.wiktionary.org', '*.m.mediawiki.org', '*.m.wikipedia.org', '*.m.wikibooks.org', '*.m.wikidata.org', '*.m.wikimedia.org', '*.m.wikimediafoundation.org', '*.m.wikinews.org', '*.m.wikiquote.org', '*.m.wikisource.org', '*.m.wikiversity.org', '*.m.wikivoyage.org', '*.m.wiktionary.org', '*.zero.wikipedia.org', 'mediawiki.org', 'wikibooks.org', 'wikidata.org', 'wikimedia.org', 'wikimediafoundation.org', 'wikinews.org', 'wikiquote.org', 'wikisource.org', 'wikiversity.org', 'wikivoyage.org', 'wiktionary.org', 'wikipedia.org'
```