### PR TITLE
Revamp Wikipedia Query Generator

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,8 +32,8 @@ from helpers import BingAccountError
 verbose = False
 totalPoints = 0
 
-SCRIPT_VERSION = "3.13.0"
-SCRIPT_DATE = "September 09, 2015"
+SCRIPT_VERSION = "3.14.0"
+SCRIPT_DATE = "September 11, 2015"
 
 def earnRewards(config, httpHeaders, userAgents, reportItem, password):
     """Earns Bing! reward points and populates reportItem"""

--- a/pkg/queryGenerators/wikipedia.py
+++ b/pkg/queryGenerators/wikipedia.py
@@ -8,12 +8,38 @@
 import re
 import helpers
 import urllib2
-from random import randint
+from random import randint, shuffle
 from datetime import date
 from bingRewards import BingRewards
 
-month_names = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
-QUERY_URL = "http://en.wikipedia.org/wiki/{0}_{1}".format(month_names[date.today().month - 1], date.today().strftime("%d"))
+MONTH_NAMES = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+QUERY_URL = "https://en.wikipedia.org/wiki/{0}_{1}?action=raw".format(MONTH_NAMES[date.today().month - 1], date.today().strftime("%d").strip("0"))
+WIKIPEDIA_SECTION_PATTERN = re.compile(r'==([^\n]+)==\n(.+?)\n\n', re.S)
+WIKIPEDIA_LINK_PATTERN = re.compile(r'\[\[(?:[^|\]]*\|)?([a-zA-Z\s]+?)\]\]')
+"""
+higher weight = higher priority(relativly)
+assuming "events" weight is 4 and "births" weight is 1:
+if "events" section has 20 links and "births" section has 20 links
+"events" section will be favored 4 to 1
+
+with the same weights:
+if "events" has 20 links and "births" has 40 links
+"events" will be favored 2 to 1
+
+How the math works:
+"events" weight is 4 and has 20 links
+each link will be added to the search pool 4 times generating 80 event links
+
+after a link is chosen from the pool to be returned as a query
+all other instances of the link are removed
+"""
+DEFAULT_SECTION_WEIGHT = 2
+DEFAULT_SECTION_WEIGHTS = {
+    "events": 4,
+    "holidays and observances": 4,
+    "births": 1,
+    "deaths": 1
+}
 
 class queryGenerator:
     def __init__(self, br):
@@ -44,27 +70,69 @@ class queryGenerator:
         with self.bingRewards.opener.open(request) as response:
             page = helpers.getResponseBody(response)
 
-        if page.strip() == "": raise ValueError("wikipedia page is empty")
+        # check that the page has content
+        if page.strip() == "":
+            raise ValueError("Wikipedia page is empty")
 
-        # get rid of new lines
-        page = page.replace("\n", "")
-        # seperate out the guts of the article
-        page = re.search('id="Events"(.+?)id="External_links"', page, re.I)
-        if page == None:
-            raise ValueError("wiki page has no contents")
-        # seperate out each result
-        searchTerms = re.findall(r'<li.+?<a href="/wiki/.+?".*?>([a-zA-Z\s]+?)</a>.*?</li>', page.group(1))
+        # convert history to lowercase
+        history = [x.trim().lower() for x in history]
+
+        # get sections of the page (ie. Events, Births, Deaths, Holidays)
+        rawSections = WIKIPEDIA_SECTION_PATTERN.findall(page)
+
+        if len(rawSections) == 0:
+            raise ValueError("Wikipedia page is empty")
+
+        # a list of search terms
+        searchTerms = []
+
+        for sectionName, conts in rawSections:
+            section = sectionName.lower()
+            # skip unwanted sections
+            if section in ["external links"]:
+                continue
+
+            # extract search terms
+            rawTerms = WIKIPEDIA_LINK_PATTERN.findall(conts)
+
+            # skip empty sections
+            if len(rawTerms) == 0:
+                continue
+
+            terms = []
+            # check each term against history
+            for term in rawTerms:
+                # humans search in lowercase
+                term = term.lower()
+                # check if the term was searched for before
+                if term not in history:
+                    terms.append(term)
+
+            # entire section is in history... skip it
+            if len(terms) == 0:
+                continue
+
+            # section search weight
+            weight = DEFAULT_SECTION_WEIGHT
+            if section in DEFAULT_SECTION_WEIGHTS:
+                weight = DEFAULT_SECTION_WEIGHTS[section]
+
+            # add each search term list the number of weighted times
+            for i in range(weight):
+                searchTerms.extend(terms)
+
+        # randomize the search terms for good measure
+        shuffle(searchTerms)
 
         queries = set()
         queriesNeeded = queriesToGenerate
+        # loop until we have enough queries or run out of things to search for
         while queriesNeeded > 0 and len(searchTerms) > 0:
             ri = randint(0, len(searchTerms) - 1)
-            # ignore things in your history
-            if searchTerms[ri] in history:
-                del searchTerms[ri]
-                continue
+            # add current term to queries
             queries.add(searchTerms[ri])
-            del searchTerms[ri]
+            # remove each instance of current term from searchTerms
+            searchTerms = filter(lambda x: x != searchTerms[ri], searchTerms)
             queriesNeeded -= 1
 
         return queries

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,17 @@
-Current version 3.13.0
+Current version 3.14.0
+
+3.14.0  *) @amayer5125, Revamp Wikipedia Query Generator
+           Search raw text instead of html page
+               Decrease download size
+               Increase parsability
+               Respect Wikipedia API rules
+           Call correct page for days with single digit
+               ie. September_9 vs September_09
+               Removes need for http redirect
+           Add weight to sections to favor events and holidays over people
+           Compile regex
+           Search in lowercase (more human like)
+           Shuffle parsed search terms to increase entropy
 
 3.13.0  *) @amayer5125, Update User Agents To Latest Versions
 


### PR DESCRIPTION
Search raw text instead of html page
    -Decrease download size
    -Increase parsability
    -Respect Wikipedia API rules
Call correct page for days with single digit
    -ie. September_9 vs September_09
    -Removes need for http redirect
Add weight to sections to favor events and holidays over people
Compile regex
Search in lowercase (more human like)
Shuffle parsed search terms to increase entropy