### PR TITLE
Updating bingAuth to handle changes for a new ppsxParam value

### DIFF
--- a/pkg/bingAuth.py
+++ b/pkg/bingAuth.py
@@ -178,6 +178,8 @@ class BingAuth:
             ppsxParam = ",M:"
         elif ",g:" in page:
             ppsxParam = ",g:"
+        elif ",j:" in page:
+            ppsxParam = ",j:"
         else:
             ppsxParam = ",d:"
         s = page.index(ppsxParam)


### PR DESCRIPTION
Looks like something changed on the bing Auth side. Just a quick fix for the problem.