### PR TITLE
Allow main.py to run from alternate directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 *.swp
 config.xml
+.DS_Store
+/*.xml

--- a/main.py
+++ b/main.py
@@ -17,8 +17,10 @@ import urllib2
 from socket import error as SocketError
 import errno
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "pkg"))
-sys.path.append(os.path.join(os.path.dirname(__file__), "pkg", "queryGenerators"))
+
+file = os.path.realpath(__file__)
+sys.path.append(os.path.join(os.path.dirname(file), "pkg"))
+sys.path.append(os.path.join(os.path.dirname(file), "pkg", "queryGenerators"))
 
 from bingAuth import BingAuth, AuthenticationError
 from bingRewards import BingRewards
@@ -263,13 +265,16 @@ if __name__ == "__main__":
         usage()
         sys.exit(1)
 
-    configFile = os.path.join(os.path.dirname(__file__), "config.xml")
+    configFile = ""
+    configFileName = None
+  
     showFullReport = False
     for o, a in opts:
         if o in ("-h", "--help"):
             usage()
             sys.exit()
         elif o in ("-f", "--configFile"):
+            configFileName = a
             configFile = a
         elif o in ("-r", "--full-report"):
             showFullReport = True
@@ -280,6 +285,16 @@ if __name__ == "__main__":
             sys.exit()
         else:
             raise NotImplementedError("option '" + o + "' is not implemented")
+
+    #if no config file was specified as an option use the default 
+    if configFileName is None : 
+        configFileName = "config.xml"
+    
+    #if the file doesn't exist, look for it relative to the working and current dirs
+    if not os.path.isfile(configFile):
+        configFile = os.path.join(os.path.dirname(os.path.realpath(__file__)), configFileName)
+        if not os.path.isfile(configFile):
+            configFile = os.path.join(os.getcwd(), configFileName)
 
     print "%s - script started" % helpers.getLoggingTime()
     print "-" * 80


### PR DESCRIPTION
This change allows the main.py to be run from anywhere using a symlink somewhere in the path from any directory containing configuration files.  

For example:
If a symlink is setup such that /usr/local/bin/bingrewards  ->  main.py  (assuming /usr/local/bin is in the PATH)  a user can have a directory of config files and simply start each of those by changing into that directory and specifying just the file name without the full path.

```
cd ~/myBingRewardsCfg
bingrewards -f config-file1.xml
bingrewards -f config-file2.xml
```

alternatively a user could launch these from anywhere if the config files exist in the root directory of the project (next to main.py) again not needing to input the entire path.
(assuming that configA.xml and configB.xml exist in BingRewards  project directory)

```
bingrewards -f configA.xml
bingrewards -f configB.xml
```

This is further supported by ignoring all .xml files in the root of the project directory by git.

---

 Libraries are loaded from location relative to the main.py
 file.  This allows us to use a symlink in another directory
 (such as /usr/local/bin) to launch the program.

 Config files can be specified on the command line  as just
 a file name if they reside in either the working directory
 or the current diretory when the program is launched

 also ignore all xml configuration files in root
