### PR TITLE
Fix incorrect "no searches found" error

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,8 +32,8 @@ from helpers import BingAccountError
 verbose = False
 totalPoints = 0
 
-SCRIPT_VERSION = "3.14.7"
-SCRIPT_DATE = "June 29, 2016"
+SCRIPT_VERSION = "3.14.8"
+SCRIPT_DATE = "August 22, 2016"
 
 def earnRewards(config, httpHeaders, userAgents, reportItem, password):
     """Earns Bing! reward points and populates reportItem"""

--- a/pkg/bingRewards.py
+++ b/pkg/bingRewards.py
@@ -227,8 +227,7 @@ class BingRewards:
         BING_QUERY_SUCCESSFULL_RESULT_MARKER_MOBILE = '<div id="content">'
         IG_PING_LINK = "http://www.bing.com/fd/ls/GLinkPing.aspx"
         IG_NUMBER_PATTERN = re.compile(r'IG:"([^"]+)"')
-        IG_SEARCH_RESULTS_PATTERN = re.compile(r'<ol\s[^>]*id="b_results".+')
-        IG_SEARCHS_PATTERN = re.compile(r'<li\s[^>]*class="b_algo"[^>]*><h2><a\s[^>]*href="(http[^"]+)"\s[^>]*h="([^"]+)"')
+        IG_SEARCHES_PATTERN = re.compile(r'<li\s[^>]*class="b_algo"[^>]*><h2><a\s[^>]*href="(http[^"]+)"\s[^>]*h="([^"]+)"')
 
         res = self.RewardResult(reward)
         if reward.isAchieved():
@@ -329,39 +328,35 @@ class BingRewards:
                     ig_number = IG_NUMBER_PATTERN.search(page)
                     if ig_number is not None:
                         ig_number = ig_number.group(1)
-                        # get search results (from b_results ol to end of line)
-                        ig_results = IG_SEARCH_RESULTS_PATTERN.search(page)
-                        if ig_results is not None:
-                            # separate search results
-                            ig_searches = IG_SEARCHS_PATTERN.findall(ig_results.group(0))
-                            # make sure we have at least 1 search
-                            if len(ig_searches) > 0:
-                                # get a random link to open
-                                ig_max_rand = min(self.openTopLinkRange, len(ig_searches) - 1)
-                                # number of the link we will use
-                                ig_link_num = random.randint(0, ig_max_rand)
-                                ig_link = "{0}?IG={1}&{2}".format(
-                                    IG_PING_LINK,
-                                    urllib.quote_plus(ig_number),
-                                    urllib.quote_plus(ig_searches[ig_link_num][1])
-                                )
+                        ig_searches = IG_SEARCHES_PATTERN.findall(page)
+                        # make sure we have at least 1 search
+                        if len(ig_searches) > 0:
+                            # get a random link to open
+                            ig_max_rand = min(self.openTopLinkRange, len(ig_searches) - 1)
+                            # number of the link we will use
+                            ig_link_num = random.randint(0, ig_max_rand)
+                            ig_link = "{0}?IG={1}&{2}".format(
+                                IG_PING_LINK,
+                                urllib.quote_plus(ig_number),
+                                urllib.quote_plus(ig_searches[ig_link_num][1])
+                            )
 
-                                # sleep a reasonable amount of time before clicking the link
-                                # use defaults to save space in config
-                                t = random.uniform(0.75, 3.0)
-                                time.sleep(t)
+                            # sleep a reasonable amount of time before clicking the link
+                            # use defaults to save space in config
+                            t = random.uniform(0.75, 3.0)
+                            time.sleep(t)
 
-                                # open the random link
-                                request = urllib2.Request(url = ig_link, headers = bingCommon.HEADERS)
-                                request.headers["Referer"] = response.url
-                                self.opener.open(request)
+                            # open the random link
+                            request = urllib2.Request(url = ig_link, headers = bingCommon.HEADERS)
+                            request.headers["Referer"] = response.url
+                            self.opener.open(request)
 
-                                if verbose:
-                                    print("Followed Link {}".format(ig_link_num + 1))
-                            else:
-                                filename = helpers.dumpErrorPage(page)
-                                print "Warning! No searches were found on search results page"
-                                print "Check {0} file for more information".format(filename)
+                            if verbose:
+                                print("Followed Link {}".format(ig_link_num + 1))
+                        else:
+                            filename = helpers.dumpErrorPage(page)
+                            print "Warning! No searches were found on search results page"
+                            print "Check {0} file for more information".format(filename)
                     else:
                         filename = helpers.dumpErrorPage(page)
                         print "Warning! Could not find search result IG number"

--- a/pkg/bingRewards.py
+++ b/pkg/bingRewards.py
@@ -226,9 +226,9 @@ class BingRewards:
         BING_QUERY_SUCCESSFULL_RESULT_MARKER_PC = '<div id="b_content">'
         BING_QUERY_SUCCESSFULL_RESULT_MARKER_MOBILE = '<div id="content">'
         IG_PING_LINK = "http://www.bing.com/fd/ls/GLinkPing.aspx"
-        IG_NUMBER_PATTERN = re.compile(r'IG:"(.+?)"')
-        IG_SEARCH_RESULTS_PATTERN = re.compile(r'<ol\s.*?id="b_results"(.+?)</ol>')
-        IG_SEARCHS_PATTERN = re.compile(r'<a\s.*?href="(http.+?)".*?\sh="(.+?)"')
+        IG_NUMBER_PATTERN = re.compile(r'IG:"([^"]+)"')
+        IG_SEARCH_RESULTS_PATTERN = re.compile(r'<ol\s[^>]*id="b_results".+')
+        IG_SEARCHS_PATTERN = re.compile(r'<li\s[^>]*class="b_algo"[^>]*><h2><a\s[^>]*href="(http[^"]+)"\s[^>]*h="([^"]+)"')
 
         res = self.RewardResult(reward)
         if reward.isAchieved():
@@ -283,6 +283,7 @@ class BingRewards:
             queryGenerator = qg.queryGenerator(self)
         except ImportError:
             raise TypeError("{0} is not a module".format(self.queryGenerator))
+
         # generate a set of queries to run
         queries = queryGenerator.generateQueries(searchesCount, history)
 
@@ -326,20 +327,19 @@ class BingRewards:
                 if self.openLinkChance > random.random():
                     # get IG number
                     ig_number = IG_NUMBER_PATTERN.search(page)
-                    if ig_number != None:
+                    if ig_number is not None:
                         ig_number = ig_number.group(1)
-                        # get search results
+                        # get search results (from b_results ol to end of line)
                         ig_results = IG_SEARCH_RESULTS_PATTERN.search(page)
-                        if ig_results != None:
-                            ig_results = ig_results.group(1)
-                            # seperate search results
-                            ig_searches = IG_SEARCHS_PATTERN.findall(ig_results)
+                        if ig_results is not None:
+                            # separate search results
+                            ig_searches = IG_SEARCHS_PATTERN.findall(ig_results.group(0))
                             # make sure we have at least 1 search
                             if len(ig_searches) > 0:
                                 # get a random link to open
                                 ig_max_rand = min(self.openTopLinkRange, len(ig_searches) - 1)
-                                ig_link_num = random.randint(0, ig_max_rand)
                                 # number of the link we will use
+                                ig_link_num = random.randint(0, ig_max_rand)
                                 ig_link = "{0}?IG={1}&{2}".format(
                                     IG_PING_LINK,
                                     urllib.quote_plus(ig_number),

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,6 @@
-Current version 3.14.7
+Current version 3.14.8
+
+3.14.8  *) @jbrobst, Fix "no searches found" error when results begin with a definition
 
 3.14.7  *) @amayer5125, Update User Agent Strings
 


### PR DESCRIPTION
After inspecting my 'results' folder, I noticed a bunch of pages being dumped due to "no searches found" errors, even though dumped pages did in fact contain results. It turns out that results pages which begin with a definition contain an ordered list for all the possible definitions of the search. The ending tag (`</ol>`) was causing the IG_SEARCH_RESULTS_PATTERN regex to end at the end of the definition list rather than actually capture the ordered list of results.

To fix this, I have the search results pattern simply capture to the end of the line (all results appear on the same line of the HTML) and then only capture 'web' results (the list items with the b_algo class). Note that my replacement regexes make the same assumptions about the HTML formatting as before (no escaped quotes, spacing, etc.).

Ultimately, this bug is a good example of why regex is a poor choice for parsing HTML. However, I decided to just fix what already exists rather than replacing everything with HTMLParser-based code because MicrosoftRewards is right around the corner and will most likely break everything anyway.