### PR TITLE
Pass all quizzes - Fix #238/#240

### DIFF
--- a/pkg/bingFlyoutParser.py
+++ b/pkg/bingFlyoutParser.py
@@ -63,7 +63,7 @@ class Reward:
         EARN_MORE_CREDITS    = (13,   "Earn more credits",                 None, False, Action.INFORM)
         SEARCH_AND_EARN      = (14,   "Search and earn",                   None, False, Action.SEARCH)
         THURSDAY_BONUS       = (15,   "Thursday bonus",                    None, False, Action.PASS)
-        RE_QUIZ              = (16,   re.compile(".*Q|quiz.*"),            None, True,  Action.PASS)
+        RE_QUIZ              = (16,   re.compile(r"\b[Qq]uiz\b"),          None, True,  Action.PASS)
 
         ALL = (RE_EARN_CREDITS_PASS, RE_EARN_CREDITS, SEARCH_MOBILE, SEARCH_PC, YOUR_GOAL, MAINTAIN_GOLD,
                REFER_A_FRIEND, SEND_A_TWEET, RE_EARNED_CREDITS, COMPLETED, SILVER_STATUS, INVITE_FRIENDS,

--- a/pkg/bingFlyoutParser.py
+++ b/pkg/bingFlyoutParser.py
@@ -63,13 +63,11 @@ class Reward:
         EARN_MORE_CREDITS    = (13,   "Earn more credits",                 None, False, Action.INFORM)
         SEARCH_AND_EARN      = (14,   "Search and earn",                   None, False, Action.SEARCH)
         THURSDAY_BONUS       = (15,   "Thursday bonus",                    None, False, Action.PASS)
-        LIGHTSPEED_QUIZ      = (16,   "Lightspeed quiz",                   None, False, Action.PASS)
-        COFFEE_BREAK_QUIZ    = (17,   "Coffee break quiz",                 None, False, Action.PASS)
-        SUPERSONIC_QUIZ      = (18,   "Supersonic quiz",                   None, False, Action.PASS)
+        RE_QUIZ              = (16,   re.compile(r"quiz"),                 None, True,  Action.PASS)
 
         ALL = (RE_EARN_CREDITS_PASS, RE_EARN_CREDITS, SEARCH_MOBILE, SEARCH_PC, YOUR_GOAL, MAINTAIN_GOLD,
                REFER_A_FRIEND, SEND_A_TWEET, RE_EARNED_CREDITS, COMPLETED, SILVER_STATUS, INVITE_FRIENDS,
-               EARN_MORE_CREDITS, SEARCH_AND_EARN, THURSDAY_BONUS, LIGHTSPEED_QUIZ, COFFEE_BREAK_QUIZ, SUPERSONIC_QUIZ)
+               EARN_MORE_CREDITS, SEARCH_AND_EARN, THURSDAY_BONUS, RE_QUIZ)
 
     def __init__(self):
         self.url = ""               # optional

--- a/pkg/bingFlyoutParser.py
+++ b/pkg/bingFlyoutParser.py
@@ -43,7 +43,6 @@ class Reward:
 
         SEARCH_AND_EARN_DESCR_RE = re.compile(r"Earn up to (\d+) points? (?:per day|today), (\d+) points? per search")
         EARN_CREDITS_RE = re.compile("Earn (\d+) credits?")
-        QUIZ_RE = re.compile(".*quiz.*", flags=re.IGNORECASE)
 
 #       Alias                   Index Reward.name
 #                           optional(Reward.description)                         isRe?  Action
@@ -64,7 +63,7 @@ class Reward:
         EARN_MORE_CREDITS    = (13,   "Earn more credits",                 None, False, Action.INFORM)
         SEARCH_AND_EARN      = (14,   "Search and earn",                   None, False, Action.SEARCH)
         THURSDAY_BONUS       = (15,   "Thursday bonus",                    None, False, Action.PASS)
-        RE_QUIZ              = (16,   QUIZ_RE,                             None, True,  Action.PASS)
+        RE_QUIZ              = (16,   re.compile(".*Q|quiz.*"),            None, True,  Action.PASS)
 
         ALL = (RE_EARN_CREDITS_PASS, RE_EARN_CREDITS, SEARCH_MOBILE, SEARCH_PC, YOUR_GOAL, MAINTAIN_GOLD,
                REFER_A_FRIEND, SEND_A_TWEET, RE_EARNED_CREDITS, COMPLETED, SILVER_STATUS, INVITE_FRIENDS,

--- a/pkg/bingFlyoutParser.py
+++ b/pkg/bingFlyoutParser.py
@@ -43,6 +43,7 @@ class Reward:
 
         SEARCH_AND_EARN_DESCR_RE = re.compile(r"Earn up to (\d+) points? (?:per day|today), (\d+) points? per search")
         EARN_CREDITS_RE = re.compile("Earn (\d+) credits?")
+        QUIZ_RE = re.compile(".*quiz.*", flags=re.IGNORECASE)
 
 #       Alias                   Index Reward.name
 #                           optional(Reward.description)                         isRe?  Action
@@ -63,7 +64,7 @@ class Reward:
         EARN_MORE_CREDITS    = (13,   "Earn more credits",                 None, False, Action.INFORM)
         SEARCH_AND_EARN      = (14,   "Search and earn",                   None, False, Action.SEARCH)
         THURSDAY_BONUS       = (15,   "Thursday bonus",                    None, False, Action.PASS)
-        RE_QUIZ              = (16,   re.compile(r"quiz"),                 None, True,  Action.PASS)
+        RE_QUIZ              = (16,   QUIZ_RE,                             None, True,  Action.PASS)
 
         ALL = (RE_EARN_CREDITS_PASS, RE_EARN_CREDITS, SEARCH_MOBILE, SEARCH_PC, YOUR_GOAL, MAINTAIN_GOLD,
                REFER_A_FRIEND, SEND_A_TWEET, RE_EARNED_CREDITS, COMPLETED, SILVER_STATUS, INVITE_FRIENDS,


### PR DESCRIPTION
Added regex to pass all quizzes (with the word "quiz" in the title). I tested this on one of my accounts and no 400 error showed. Please test and let me know if you encounter any issues.