### PR TITLE
adjust reward name to address 302 errors, previously addressed in #169

### DIFF
--- a/pkg/bingFlyoutParser.py
+++ b/pkg/bingFlyoutParser.py
@@ -60,14 +60,14 @@ class Reward:
         COMPLETED            = (10,    "Completed",                        None, False, Action.PASS)
         SILVER_STATUS        = (11,   "Silver Status",                     None, False, Action.PASS)
         INVITE_FRIENDS       = (12,   "Invite friends",                    None, False, Action.PASS)
-        EARN_MORE_CREDITS    = (13,   "Earn more credits",                 None, False, Action.INFORM)
+        EARN_MORE_POINTS     = (13,   "Earn more points",                  None, False, Action.INFORM)
         SEARCH_AND_EARN      = (14,   "Search and earn",                   None, False, Action.SEARCH)
         THURSDAY_BONUS       = (15,   "Thursday bonus",                    None, False, Action.PASS)
         RE_QUIZ              = (16,   re.compile(r"\b[Qq]uiz\b"),          None, True,  Action.PASS)
 
         ALL = (RE_EARN_CREDITS_PASS, RE_EARN_CREDITS, SEARCH_MOBILE, SEARCH_PC, YOUR_GOAL, MAINTAIN_GOLD,
                REFER_A_FRIEND, SEND_A_TWEET, RE_EARNED_CREDITS, COMPLETED, SILVER_STATUS, INVITE_FRIENDS,
-               EARN_MORE_CREDITS, SEARCH_AND_EARN, THURSDAY_BONUS, RE_QUIZ)
+               EARN_MORE_POINTS, SEARCH_AND_EARN, THURSDAY_BONUS, RE_QUIZ)
 
     def __init__(self):
         self.url = ""               # optional


### PR DESCRIPTION
Discussed as part of #262 