### PR TITLE
Corrected all instances of the typo "Bing!"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ addSearchesMobileSalt Random number of added mobile searches
 
 ### Accounts
 You can have as many account tags as you need.  
-**Note**: User-Agent fields are optional. If omitted a random User-Agent will be selected. Use caution when entering a custom User-Agent. If User-Agent is not associated with a common browser Bing! might flag you as a bot.  
+**Note**: User-Agent fields are optional. If omitted a random User-Agent will be selected. Use caution when entering a custom User-Agent. If User-Agent is not associated with a common browser Bing might flag you as a bot.  
 **Note**: Two-Factor Authentication (2FA) is not supported.
 ```xml
 <account disabled="(true|false)">
@@ -74,10 +74,10 @@ Windows: Use build in Task Scheduler
 ## References
 - For more information, including how to use this, please, take a look at my blog post:
 [here](http://sealemar.blogspot.com/2012/12/bing-rewards-automation.html)
-- To find out how to convert Bing! Rewards points to cash, read my second post in this series:
+- To find out how to convert Bing Rewards points to cash, read my second post in this series:
 [here](http://sealemar.blogspot.com/2013/04/bing-rewards-points-to-cash.html)
-- [Bing! Rewards Automation version 2.0](http://sealemar.blogspot.com/2013/06/bing-rewards-automation-version-2.html)
-- [Bing! Rewards Automation version 3.0](http://sealemar.blogspot.com/2013/10/bing-rewards-automation-version-30.html) -- _added events support - notifications and retries_
-- [Configuration for Bing! Rewards Automation script](http://sealemar.blogspot.com/2013/10/configuration-for-bing-rewards.html)
-- [Bing! Rewards Automation script: Unix Cron](http://sealemar.blogspot.com/2013/10/bing-rewards-automation-script-unix-cron.html)
+- [Bing Rewards Automation version 2.0](http://sealemar.blogspot.com/2013/06/bing-rewards-automation-version-2.html)
+- [Bing Rewards Automation version 3.0](http://sealemar.blogspot.com/2013/10/bing-rewards-automation-version-30.html) -- _added events support - notifications and retries_
+- [Configuration for Bing Rewards Automation script](http://sealemar.blogspot.com/2013/10/configuration-for-bing-rewards.html)
+- [Bing Rewards Automation script: Unix Cron](http://sealemar.blogspot.com/2013/10/bing-rewards-automation-script-unix-cron.html)
 - [Troubleshooting guide](http://sealemar.blogspot.com/2014/06/troubleshooting-bing-rewards-automation.html)

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ SCRIPT_VERSION = "3.15.1"
 SCRIPT_DATE = "September 13, 2017"
 
 def earnRewards(config, httpHeaders, userAgents, reportItem, password):
-    """Earns Bing! reward points and populates reportItem"""
+    """Earns Bing reward points and populates reportItem"""
     noException = False
     try:
         if reportItem is None: raise ValueError("reportItem is None")
@@ -137,7 +137,7 @@ def usage():
     print "        --version            print version info"
 
 def printVersion():
-    print "Bing! Rewards Automation script: <http://sealemar.blogspot.com/2012/12/bing-rewards-automation.html>"
+    print "Bing Rewards Automation script: <http://sealemar.blogspot.com/2012/12/bing-rewards-automation.html>"
     print "Version: " + SCRIPT_VERSION + " from " + SCRIPT_DATE
     print "See 'version.txt' for the list of changes"
     print "This code is published under LGPL v3 <http://www.gnu.org/licenses/lgpl-3.0.html>"

--- a/pkg/bingFlyoutParser.py
+++ b/pkg/bingFlyoutParser.py
@@ -5,7 +5,7 @@
 #
 
 """
-Bing! flyout page parser
+Bing flyout page parser
 
 Usage:
     from bingFlyoutParser import Reward, parseFlyoutPage
@@ -19,7 +19,7 @@ import HTMLParser
 import re
 
 class Reward:
-    "A class to represent a Bing! reward"
+    "A class to represent a Bing reward"
 
     class Type:
         class Action:
@@ -116,7 +116,7 @@ def parseFlyoutPage(page, bing_url):
 ######################################################
 class __HTMLRewardsParser(HTMLParser.HTMLParser):
     """
-    Gets Bing! flyout page starting from tag
+    Gets Bing flyout page starting from tag
     <div id="messageContainer"> to the tag
     <div id="bottomContainer">, excluding the last one
 

--- a/pkg/bingHistory.py
+++ b/pkg/bingHistory.py
@@ -10,7 +10,7 @@ import helpers
 
 def __parseResultsArea1(resultsArea):
     """
-    Parses <div id="resultsArea">...</div> from Bing! history page
+    Parses <div id="resultsArea">...</div> from Bing history page
     Returns a list of queries (can be empty list)
     """
     startMarker = '<span class="query_t">'
@@ -48,7 +48,7 @@ def __isApproach(page, startMarker, endMarker):
 
 def __parseResultsArea2(resultsArea):
     """
-    Parses results from Bing! history page
+    Parses results from Bing history page
     Returns a list of queries (can be empty list)
     """
     startMarker = '<span class="sh_item_qu_query">'
@@ -75,13 +75,13 @@ def __parseResultsArea2(resultsArea):
 
 def parse(page):
     """
-    Parses Bing! history page and returns a set of queries for today
+    Parses Bing history page and returns a set of queries for today
     Can be an empty set
     """
     if page is None: raise TypeError("page is None")
     if page.strip() == "":
         print "-------------------------------"
-        print "Warning: Bing! history is empty"
+        print "Warning: Bing history is empty"
         print "-------------------------------"
         print
         return set()
@@ -101,7 +101,7 @@ def parse(page):
 
 def getBingHistoryTodayURL():
     """
-    Returns URL to today's Bing! history
+    Returns URL to today's Bing history
     i.e. "https://ssl.bing.com/profile/history?d=20121217"
     """
     BING_HISTORY_URL = "https://ssl.bing.com/profile/history?d="

--- a/pkg/bingRewards.py
+++ b/pkg/bingRewards.py
@@ -103,7 +103,7 @@ class BingRewards:
         url = self.BING_FLYOUT_PAGE
         request = urllib2.Request(url = url, headers = self.httpHeaders)
 
-# commenting the line below, because on 10/25/2013 Bing! started to return an empty flyout page if referer is other than http://www.bing.com
+# commenting the line below, because on 10/25/2013 Bing started to return an empty flyout page if referer is other than http://www.bing.com
         #request.add_header("Referer", "http://www.bing.com/rewards/dashboard")
 
         with self.opener.open(request) as response:
@@ -250,7 +250,7 @@ class BingRewards:
 
         indCol = bfp.Reward.Type.Col.INDEX
 
-# get a set of queries from today's Bing! history
+# get a set of queries from today's Bing history
         url = bingHistory.getBingHistoryTodayURL()
         request = urllib2.Request(url = url, headers = self.httpHeaders)
         with self.opener.open(request) as response:
@@ -318,7 +318,7 @@ class BingRewards:
 
         for query in queries:
             if i > 1:
-# sleep some time between queries (don't worry Bing! ;) )
+# sleep some time between queries (don't worry Bing ;) )
                 t = self.betweenQueriesInterval + random.uniform(0, self.betweenQueriesSalt)
                 time.sleep(t)
 

--- a/pkg/queryGenerators/bing.py
+++ b/pkg/queryGenerators/bing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 
 #
-# Bing! queries generator
+# Bing queries generator
 # developed by Sergey Markelov (2013)
 #
 
@@ -119,12 +119,12 @@ class queryGenerator:
 
     def generateQueries(self, queriesToGenerate, history, maxQueryLen = MAX_QUERY_LEN):
         """
-        parses Bing! news page and generates a set of unique queries to run on Bing!
+        parses Bing news page and generates a set of unique queries to run on Bing
         A query is considered to be unique if it distingueshes from any other query at
         least in a meaning letter. Where meaning letter is any ASCII charecter, but
         terminators (space, comma, colon, etc.)
 
-        Url good enough to get Bing! news
+        Url good enough to get Bing news
         http://www.bing.com/news?q=world+news
 
         param queriesToGenerate the number of queries to return

--- a/version.txt
+++ b/version.txt
@@ -158,7 +158,7 @@ Current version 3.15.1
 3.5.3   *) Fixed https://github.com/sealemar/BingRewards/issues/45#issuecomment-45700693
            Two bugs were addressed:
            1. bingAuth - sso is not used any more
-           2. bingQueriesGenerator - Bing! spontaneously returns PC style page for mobile
+           2. bingQueriesGenerator - Bing spontaneously returns PC style page for mobile
               searches. This fix check for both of them.
 
 3.5.2   *) @JustLikeIcarus Added missing commas to list of mobile user agents
@@ -213,22 +213,22 @@ Current version 3.15.1
            to
            BING_QUERY_SUCCESSFULL_RESULT_MARKER = '<div id="b_content">'
 
-3.1.6   *) Case insensitive match on flyout strings. Bing! changed "Search and Earn" to "Search and earn"
+3.1.6   *) Case insensitive match on flyout strings. Bing changed "Search and Earn" to "Search and earn"
 
 3.1.5   *) Fixed Live auth. Credits to jbrobst (GitHub). https://github.com/sealemar/BingRewards/issues/18
 
 3.1.4   *) Fixed a bug in lifetime credits parser. https://github.com/sealemar/BingRewards/issues/13
 
-3.1.3   *) As per https://github.com/sealemar/BingRewards/issues/13 - Bing! Dashboard HTML was changed. This fix accounts for the change.
+3.1.3   *) As per https://github.com/sealemar/BingRewards/issues/13 - Bing Dashboard HTML was changed. This fix accounts for the change.
 
-3.1.2   *) Increased intervals in config.xml. It looks like Bing! black lists an IP if it abuses with frequent requests.
+3.1.2   *) Increased intervals in config.xml. It looks like Bing black lists an IP if it abuses with frequent requests.
 
-3.1.1   *) Bing! authentication URL both for LiveId and Facebook now contains escape characters (http:// is http\x3a\x2f\x2f, for example). Those need to be converted back to normal URL. See [http://docs.python.org/2/library/codecs.html#python-specific-encodings]
+3.1.1   *) Bing authentication URL both for LiveId and Facebook now contains escape characters (http:// is http\x3a\x2f\x2f, for example). Those need to be converted back to normal URL. See [http://docs.python.org/2/library/codecs.html#python-specific-encodings]
         +) Script current version date is now outputed with "--version" argument
 
-3.1     +) config.xml - general.betweenAccountsInterval and general.betweenAccountsSalt - time to sleep between two accounts - not to annoy Bing!
+3.1     +) config.xml - general.betweenAccountsInterval and general.betweenAccountsSalt - time to sleep between two accounts - not to annoy Bing
 
-3.0.3   *) commenting the referer in BingFlyoutParser, because on 10/25/2013 Bing! started to return an empty flyout page if referer is other than http://www.bing.com
+3.0.3   *) commenting the referer in BingFlyoutParser, because on 10/25/2013 Bing started to return an empty flyout page if referer is other than http://www.bing.com
 
 3.0.2   *) the script now looks for default config.xml in the directory where it is located
         *) "pkg" project subfolder is now searched under the script directory
@@ -266,7 +266,7 @@ Current version 3.15.1
 
 2.4     +) main.py - total points earned during the session is now printed out when the script finishes
 
-2.3     *) bingQueriesGenerator - changed parsing HTML tag to comply with new Bing! output
+2.3     *) bingQueriesGenerator - changed parsing HTML tag to comply with new Bing output
 
 2.2     +) bingFlyoutParser now understands descriptions
         +) bingFlyoutParser + Reward.Action.PASS for 'Silver Status' and for 'Get the best of Bing by signing in with Facebook.' description
@@ -283,7 +283,7 @@ Current version 3.15.1
         *) Authentication configuration moved to config.xml. No direct script changes to use different account information are needed.
            config.xml accepts Live and Facebook authentication types. Any number of authentications can be added to config.xml.
 
-1.4     Bing! rewards page changed. Bing! flyout is now requested with http://www.bing.com/rewards/dashboard in a Referer header, otherwise it is empty
+1.4     Bing rewards page changed. Bing flyout is now requested with http://www.bing.com/rewards/dashboard in a Referer header, otherwise it is empty
 
 1.3     Don't raise exception if history page is empty - warn instead.
         added to bingRewards.py:
@@ -291,6 +291,6 @@ Current version 3.15.1
 
 1.2     Configurable salt to sleep between requests
 
-1.1     Bing! news changed the output format for tag <span class="sn_snip">. This version works both with the former and the latter behavior
+1.1     Bing news changed the output format for tag <span class="sn_snip">. This version works both with the former and the latter behavior
 
 1.0     First implementation plus whatever was else before I created this file :)


### PR DESCRIPTION
As mentioned in https://github.com/sealemar/BingRewards/issues/277 "Bing!" is not the correct name.
This PR will change all instances of "Bing!" to the correct "Bing". :cat2: 