### PR TITLE
Add Docker functionality

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+config.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:2-alpine
+# Following label schema convention described at http://label-schema.org/rc1/
+LABEL \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.name="BingRewards" \
+    org.label-schema.vcs-url="http://github.com/sealemar/BingRewards" \
+    org.label-schema.description="BingRewards is an automated point earning script that works with Bing.com to earn points that can be redeemed for giftcards." \
+    org.label-schema.docker.cmd="docker run -it --rm -v /path/to/config.xml:/usr/src/app/config.xml elisiano/bingrewards" \
+    org.label-schema.docker.maintainer="Elisiano Petrini <elisiano@gmail.com>"
+
+COPY . /usr/src/app
+RUN apk --no-cache add bash mailx
+WORKDIR /usr/src/app
+CMD ["python", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ LABEL \
     org.label-schema.docker.maintainer="Elisiano Petrini <elisiano@gmail.com>"
 
 COPY . /usr/src/app
-RUN apk --no-cache add bash mailx
 WORKDIR /usr/src/app
+RUN apk --no-cache add bash mailx \
+  && pip install -r requirements.txt
 CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ Windows
 > python main.py
 ```
 Docker
+
 A Dockerfile is included in this repository. You can build your local version as follows:
 ```
 docker build -t bingrewards .
 ```
 Once that's built you can run it as follows (make sure you adjust the path to your `config.xml`)
 ```
-docker run -it --rm -v /path/to/config.xml:/usr/src/app/config.xml bingrewards
+docker run -it --rm -v `pwd`/config.xml:/usr/src/app/config.xml bingrewards
 ```
 
 ## Config

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ LOCAL_CONFIG_DIR=/home/bingrewards/etc
 ```
 Windows: Use build in Task Scheduler
 
+## Docker
+A Dockerfile is included in this repository. You can build your local version as follows:
+```
+docker build -t bingrewards .
+```
+Once that's built you can run it as follows (make sure you adjust the path to your `config.xml`)
+```
+docker run -it --rm -v /path/to/config.xml:/usr/src/app/config.xml bingrewards
+```
+
 ## References
 - For more information, including how to use this, please, take a look at my blog post:
 [here](http://sealemar.blogspot.com/2012/12/bing-rewards-automation.html)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Windows
 > cd path\to\bingrewards
 > python main.py
 ```
+Docker
+A Dockerfile is included in this repository. You can build your local version as follows:
+```
+docker build -t bingrewards .
+```
+Once that's built you can run it as follows (make sure you adjust the path to your `config.xml`)
+```
+docker run -it --rm -v /path/to/config.xml:/usr/src/app/config.xml bingrewards
+```
+
 ## Config
 
 ### General
@@ -71,16 +81,6 @@ LOCAL_CONFIG_DIR=/home/bingrewards/etc
 0   1   *   *   *   sleep $(($RANDOM \% 120))m && python2 /home/bingrewards/bin/main.py 2>&1 | gzip > /home/bingrewards/var/log/bingrewards/`date "+\%Y-\%m-\%dT\%H:\%M:\%S"`.log.gz
 ```
 Windows: Use build in Task Scheduler
-
-## Docker
-A Dockerfile is included in this repository. You can build your local version as follows:
-```
-docker build -t bingrewards .
-```
-Once that's built you can run it as follows (make sure you adjust the path to your `config.xml`)
-```
-docker run -it --rm -v /path/to/config.xml:/usr/src/app/config.xml bingrewards
-```
 
 ## References
 - For more information, including how to use this, please, take a look at my blog post:


### PR DESCRIPTION
as discussed in #225 I'm adding Docker functionality to this repo.

Once one of the repo administrators will setup integrations with the Docker Hub, the `org.label-schema.docker.cmd` label in the `Dockerfile` can be updated with the right tag and the instructions in the README.md can be changed to a simple `docker pull tag/imagename` instead of building the container locally.