### PR TITLE
Ignore non-convertible utf8 characters

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,8 +32,8 @@ from helpers import BingAccountError
 verbose = False
 totalPoints = 0
 
-SCRIPT_VERSION = "3.16.0"
-SCRIPT_DATE = "October 16, 2017"
+SCRIPT_VERSION = "3.16.1"
+SCRIPT_DATE = "November 1, 2017"
 
 def earnRewards(config, httpHeaders, userAgents, reportItem, password):
     """Earns Bing reward points and populates reportItem"""

--- a/pkg/bingDashboardParser.py
+++ b/pkg/bingDashboardParser.py
@@ -227,10 +227,10 @@ def checkForHit(currAction, rewardProgressCurrent, rewardProgressMax, searchLink
 
 def createReward(reward, rUrl, rName, rPC, rPM, rDesc):
     reward.url = rUrl.strip()
-    reward.name = rName.strip()
+    reward.name = rName.strip().encode('latin-1', 'ignore')
     reward.progressCurrent = rPC
     reward.progressMax = rPM
-    reward.description = rDesc.strip()
+    reward.description = rDesc.strip().encode('latin-1', 'ignore')
     if rPC == rPM:
         reward.isDone = True
 

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,7 @@
-Current version 3.16.0
+Current version 3.16.1
+
+3.16.1  *) @specu, Conversion of activity names and descriptions from unicode to ascii
+           to avoid issues with functions that don't support unicode
 
 3.16.0  *) @baltimoron, rewrote bingFlyoutParser.py as bingDashboardParser.py
 


### PR DESCRIPTION
This patch is a workaround to address certain functions being unable to handle utf8. It converts uf8 strings to ascii ignoring non-convertible characters so that the script doesnt fail altogether.