### PR TITLE
Fixes for spaces in url, substring error, and mobile search regex

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,6 +87,10 @@ def earnRewards(config, httpHeaders, userAgents, reportItem, password):
         reportItem.error = e
         print "IOError: %s" % e
 
+    except ValueError, e:
+        reportItem.error = e
+        print "ValueError: %s" % e
+
     except AuthenticationError, e:
         reportItem.error = e
         print "AuthenticationError:\n%s" % e

--- a/pkg/bingDashboardParser.py
+++ b/pkg/bingDashboardParser.py
@@ -254,7 +254,7 @@ def checkForHit(currAction, rewardProgressCurrent, rewardProgressMax, searchLink
                 return [rewardProgressCurrent, rewardProgressMax]
 
 def createReward(reward, rUrl, rName, rPC, rPM, rDesc):
-    reward.url = rUrl.strip()
+    reward.url = rUrl.strip().replace(' ', '')
     reward.name = rName.strip().encode('latin-1', 'ignore')
     reward.progressCurrent = rPC
     reward.progressMax = rPM

--- a/pkg/bingDashboardParser.py
+++ b/pkg/bingDashboardParser.py
@@ -245,7 +245,7 @@ def checkForHit(currAction, rewardProgressCurrent, rewardProgressMax, searchLink
             if currAction.get_text().lower().find('points') != -1:
                 try: 
                     rewardProgressMax = int(currAction.get_text().split(' ')[0])
-                except 
+                except: 
                     ValueError: pass
                 #Use the button div to determine whether the offer has been completed
                 btn = searchLink.find('div', class_='card-button-height text-caption text-align-center offer-complete-card-button-background border-width-2 offer-card-button-background')

--- a/pkg/bingDashboardParser.py
+++ b/pkg/bingDashboardParser.py
@@ -81,6 +81,8 @@ class Reward:
         self.isDone = False         # optional - is set if progress is "Done"
         self.description = ""
         self.tp = None              # is one of self.Type if set
+        self.hitId = None           # only for hits, needed to relay info to verify hit
+        self.hitHash = None         # same as above, needed to relay info to verify hit
 
     def isAchieved(self):
         """
@@ -253,12 +255,16 @@ def checkForHit(currAction, rewardProgressCurrent, rewardProgressMax, searchLink
                     rewardProgressCurrent = rewardProgressMax
                 return [rewardProgressCurrent, rewardProgressMax]
 
-def createReward(reward, rUrl, rName, rPC, rPM, rDesc):
-    reward.url = rUrl.strip().replace(' ', '')
+def createReward(reward, rUrl, rName, rPC, rPM, rDesc, hitId=None, hitHash=None):
+    reward.url = rUrl.strip().replace(' ','')
     reward.name = rName.strip().encode('latin-1', 'ignore')
     reward.progressCurrent = rPC
     reward.progressMax = rPM
     reward.description = rDesc.strip().encode('latin-1', 'ignore')
+    if hitId:
+        reward.hitId = hitId
+    if hitHash:
+        reward.hitHash = hitHash
     if rPC == rPM:
         reward.isDone = True
 
@@ -290,6 +296,9 @@ def createRewardNewFormat(page, title, newRwd):
     #We're going to use this as at trigger to determine whether to process the reward or throw it out. If there is no "complete" attribute (true/false) then ignore the reward
     hasComplete = -1
     relevantSegment = page[page.index(title):]
+    #need the hash for hits but it is outside of the relevant segment so get it here
+    hitHash = relevantSegment[relevantSegment.find('hash')+7:]
+    hitHash = hitHash[:hitHash.find('","')]
     relevantSegment = relevantSegment[:relevantSegment.index("}")]
     rewardName = cleanString(title)
     #check relevant segment for 'slide_0', if exists switch to slide processing branch - ignoring for now since I'm not sure slides are rewards
@@ -322,14 +331,14 @@ def createRewardNewFormat(page, title, newRwd):
                     hasComplete = 1
                 if current[1] == 'False':
                     hasComplete = 0
-                #this is the last value, once we get it we have everything we need so break
-                break
-
+            if attrType == "offerid":
+                hitIdentifier = cleanString(current[1])
+    
     #if it isn't completeable then it probably isn't a reward, so ignore it
     if hasComplete == -1:
         isValid = False
     if isValid:
-        createReward(newRwd, rewardURL, rewardName, rewardProgressCurrent, rewardProgressMax, rewardDescription)
+        createReward(newRwd, rewardURL, rewardName, rewardProgressCurrent, rewardProgressMax, rewardDescription, hitIdentifier, hitHash)
     return isValid
 
 def cleanString(strToClean):

--- a/pkg/bingRewards.py
+++ b/pkg/bingRewards.py
@@ -19,6 +19,8 @@ import bingDashboardParser as bdp
 import bingHistory
 import helpers
 
+import requests
+
 # extend urllib.addinfourl like it defines @contextmanager (to use with "with" keyword)
 urllib.addinfourl.__enter__ = lambda self: self
 urllib.addinfourl.__exit__  = lambda self, type, value, traceback: self.close()
@@ -66,7 +68,7 @@ class BingRewards:
         self.userAgents  = userAgents
         self.queryGenerator = config.queryGenerator
 
-        cookies = cookielib.CookieJar()
+        self.cookies = cookielib.CookieJar()
 
         if config.proxy:
             if config.proxy.login:
@@ -82,7 +84,7 @@ class BingRewards:
                                             #urllib2.HTTPHandler(debuglevel = 1),      # be verbose on HTTP
                                             urllib2.HTTPSHandler(),
                                             HTTPRefererHandler,                       # add Referer header on redirect
-                                            urllib2.HTTPCookieProcessor(cookies))     # keep cookies
+                                            urllib2.HTTPCookieProcessor(self.cookies))     # keep cookies
 
         else:
             self.opener = urllib2.build_opener(
@@ -90,7 +92,7 @@ class BingRewards:
                                             #urllib2.HTTPHandler(debuglevel = 1),      # be verbose on HTTP
                                             urllib2.HTTPSHandler(),
                                             HTTPRefererHandler,                       # add Referer header on redirect
-                                            urllib2.HTTPCookieProcessor(cookies))     # keep cookies
+                                            urllib2.HTTPCookieProcessor(self.cookies))     # keep cookies
 
     def getLifetimeCredits(self):
         page = self.getDashboardPage()
@@ -148,10 +150,17 @@ class BingRewards:
         e = page.index('"', s)
         t = page[s:e]
 
+        s = page.index('id="pprid"')
+        s = page.index('value="', s)
+        s += len('value="')
+        e = page.index('"', s)
+        pprid = page[s:e] 
+
         postFields = urllib.urlencode({
             "NAP"    : nap,
             "ANON"   : anon,
-            "t"      : t
+            "t"      : t,
+            "pprid"  : pprid
         })
 
         request = urllib2.Request(action, postFields, self.httpHeaders)
@@ -192,9 +201,26 @@ class BingRewards:
         """Processes bdp.Reward.Type.Action.HIT and returns self.RewardResult"""
         res = self.RewardResult(reward)
         pointsEarned = self.getRewardsPoints()
+        currPage = self.getDashboardPage()
+        startIndex = currPage.find('__RequestVerificationToken')
+        endIndex = currPage[startIndex:].find('/>')
+        #pad here to get to the correct spot
+        verificationAttr = currPage[startIndex+49:startIndex+endIndex-2]
         request = urllib2.Request(url = reward.url, headers = self.httpHeaders)
+
+        verificationData = [
+            ('id', reward.hitId),
+            ('hash', reward.hitHash),
+            ('timeZone', '-300'),
+            ('activityAmount', '1'),
+            ('__RequestVerificationToken', verificationAttr) #there was a comma here, removed it. Monitor to make sure shit still works
+        ]
+
+        verificationUrl = 'https://account.microsoft.com/rewards/api/reportactivity?refd=www.bing.com&X-Requested-With=XMLHttpRequest'
+
         with self.opener.open(request) as response:
             page = helpers.getResponseBody(response)
+            verificationRequest = requests.post(verificationUrl, headers=self.httpHeaders, cookies=self.cookies, data=verificationData)
         pointsEarned = self.getRewardsPoints() - pointsEarned
         # if HIT is against bdp.Reward.Type.RE_EARN_CREDITS - check if pointsEarned is the same to
         # pointsExpected
@@ -449,6 +475,8 @@ class BingRewards:
         if reward.isDone:
             print "is done     : true"
         print "description : %s" % reward.description
+        print "hit identifier: %s" % reward.hitId
+        print "hit hash: %s" % reward.hitHash
 
     def printRewards(self, rewards):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 bs4
+requests


### PR DESCRIPTION
-Parser is inserting spaces into certain rewards URLS, added a replace statement to catch these
-Substring value error - added a catch for this so the script can retry
-Mobile search title - Changed back from "Edge mobile search" to "Mobile search"