### PR TITLE
Randomize account order

### DIFF
--- a/main.py
+++ b/main.py
@@ -193,7 +193,9 @@ def __run(config):
 
     doSleep = False
 
-    for key, account in config.accounts.iteritems():
+    accounts = config.accounts.items()
+    random.shuffle(accounts)
+    for key, account in accounts:
         if account.disabled:
             continue
 


### PR DESCRIPTION
Shuffle accounts to avoid running multiple accounts in the same order every time.

I don't know if this is something to be concerned about, but it wouldn't hurt to randomize.
 
Note this will cause account order in logs to be randomized also.