### PR TITLE
Display current day streak as a completed activity for informational purposes only

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,8 +35,8 @@ from helpers import BingAccountError
 verbose = False
 totalPoints = 0
 
-SCRIPT_VERSION = "3.16.5"
-SCRIPT_DATE = "August 23, 2018"
+SCRIPT_VERSION = "3.16.6"
+SCRIPT_DATE = "August 24, 2018"
 
 def earnRewards(config, httpHeaders, userAgents, reportItem, password):
     """Earns Bing reward points and populates reportItem"""

--- a/pkg/bingDashboardParser.py
+++ b/pkg/bingDashboardParser.py
@@ -230,6 +230,14 @@ def createRewardNewFormat(page, title, newRwd):
             if attrType == "offerid":
                 hitIdentifier = cleanString(current[1])
     
+            if rewardName == "Current day streak":
+                hasComplete = 1
+                if attrType == "activity_progress":
+                    rewardDescription = rewardName
+                    rewardProgressCurrent = int(cleanString(current[1]))
+                    rewardProgressMax = int(cleanString(current[1]))
+                    hitIdentifier = ""
+
     #if it isn't completeable then it probably isn't a reward, so ignore it
     if hasComplete == -1:
         isValid = False

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,6 @@
-Current version 3.16.5
+Current version 3.16.6
+
+3.16.6  *) @specu, Display current day streak as a completed activity for informational purposes only
 
 3.16.5  *) @patrickbryan, Updated parsing to add back old activity page
 


### PR DESCRIPTION
It's just a dummy activity that shows the current streak you got going. It doesn't tell you whether today's activities have been completed to keep the streak going. Streak is 15 points per day, awarded after 3 ,5, 7 and 10 days.