### PR TITLE
Support daily search for level 1 accounts

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,8 +35,8 @@ from helpers import BingAccountError
 verbose = False
 totalPoints = 0
 
-SCRIPT_VERSION = "3.16.6"
-SCRIPT_DATE = "August 24, 2018"
+SCRIPT_VERSION = "3.16.7"
+SCRIPT_DATE = "August 31, 2018"
 
 def earnRewards(config, httpHeaders, userAgents, reportItem, password):
     """Earns Bing reward points and populates reportItem"""

--- a/pkg/bingDashboardParser.py
+++ b/pkg/bingDashboardParser.py
@@ -54,7 +54,7 @@ class Reward:
                             "Get the best of Bing by signing in with Facebook.", True,  Action.PASS)
         RE_EARN_CREDITS      = (2,    EARN_CREDITS_RE,                     None, True,  Action.HIT)
         SEARCH_MOBILE        = (3,    "Mobile search",                     None, False, Action.SEARCH)
-        SEARCH_PC            = (4,    "PC search",                         None, False, Action.SEARCH)
+        SEARCH_PC            = (4,    re.compile("(PC|Daily) search"),     None, True,  Action.SEARCH)
         YOUR_GOAL            = (5,    "Your goal",                         None, False, Action.INFORM)
         MAINTAIN_GOLD        = (6,    "Maintain Gold",                     None, False, Action.INFORM)
         REFER_A_FRIEND       = (7,    "Refer-A-Friend",                    None, False, Action.PASS)

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,7 @@
 Current version 3.16.6
 
+3.16.7  *) @dwait, Support daily search for level 1 accounts
+
 3.16.6  *) @specu, Display current day streak as a completed activity for informational purposes only
 
 3.16.5  *) @patrickbryan, Updated parsing to add back old activity page


### PR DESCRIPTION
Recognize the reward whose title is "Daily search" as the `PC_SEARCH` reward, as this is the title of the reward for level 1 accounts.