### PR TITLE
Recognize more reward types

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,8 +35,8 @@ from helpers import BingAccountError
 verbose = False
 totalPoints = 0
 
-SCRIPT_VERSION = "3.16.7"
-SCRIPT_DATE = "August 31, 2018"
+SCRIPT_VERSION = "3.16.8"
+SCRIPT_DATE = "September 1, 2018"
 
 def earnRewards(config, httpHeaders, userAgents, reportItem, password):
     """Earns Bing reward points and populates reportItem"""

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,6 @@
-Current version 3.16.6
+Current version 3.16.8
+
+3.16.8  *) @dwait, Recognize more reward types
 
 3.16.7  *) @dwait, Support daily search for level 1 accounts
 


### PR DESCRIPTION
Some unsupported rewards that are worth 10 points such as the daily poll and the news quiz were being treated as "hit" types even though the script does not support completing them, resulting in errors in the result directory. This commit makes them get treated like quizzes are treated now ("pass"). It also recognizes the edge search bonus as a "pass" reward instead of giving an error, and completely ignores completable rewards that don't earn any points so no requests are made to try to complete them.