### PR TITLE
Added a config option ignoreSSLErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ addSearchesDesktop: Number of extra desktop searches
 addSearchesDesktopSalt: Random number of added desktop searches  
 addSearchesMobile: Number of extra mobile searches  
 addSearchesMobileSalt: Random number of added mobile searches  
+ignoreSSLErrors: Ignore SSL errors, default is "0" (for "false", set to "1" for "true")  
 
 ### Accounts
 You can have as many account tags as you need.  

--- a/config.xml.dist
+++ b/config.xml.dist
@@ -18,7 +18,8 @@
         addSearchesDesktop="0"
         addSearchesDesktopSalt="20"
         addSearchesMobile="0"
-        addSearchesMobileSalt="20" />
+        addSearchesMobileSalt="20"
+        ignoreSSLErrors="0" />
 
     <!--
     Note: login and password are optional

--- a/main.py
+++ b/main.py
@@ -35,8 +35,8 @@ from helpers import BingAccountError
 verbose = False
 totalPoints = 0
 
-SCRIPT_VERSION = "3.16.9"
-SCRIPT_DATE = "September 9, 2018"
+SCRIPT_VERSION = "3.16.10"
+SCRIPT_DATE = "September 10, 2018"
 
 def earnRewards(config, httpHeaders, userAgents, reportItem, password):
     """Earns Bing reward points and populates reportItem"""

--- a/pkg/bingRewards.py
+++ b/pkg/bingRewards.py
@@ -11,6 +11,7 @@ import random
 import time
 import urllib
 import urllib2
+import ssl
 import importlib
 import re
 
@@ -62,11 +63,19 @@ class BingRewards:
         self.addSearchesMobileSalt  = int(config.general.addSearchesMobileSalt)
         self.openTopLinkRange       = int(config.general.openTopLinkRange)
         self.openLinkChance         = float(config.general.openLinkChance)
+        self.ignoreSSLErrors        = int(config.general.ignoreSSLErrors)
         self.httpHeaders = httpHeaders
         self.userAgents  = userAgents
         self.queryGenerator = config.queryGenerator
 
         self.cookies = cookielib.CookieJar()
+        
+        # if ignoreSSLErrors == True, create SSL Context to ignore SSL errors 
+        ctx = None
+        if self.ignoreSSLErrors:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
 
         if config.proxy:
             if config.proxy.login:
@@ -80,7 +89,7 @@ class BingRewards:
                                             urllib2.ProxyHandler( { p : proxyString for p in config.proxy.protocols } ),
                                             #urllib2.HTTPSHandler(debuglevel = 1),     # be verbose on HTTPS
                                             #urllib2.HTTPHandler(debuglevel = 1),      # be verbose on HTTP
-                                            urllib2.HTTPSHandler(),
+                                            urllib2.HTTPSHandler(context=ctx),
                                             HTTPRefererHandler,                       # add Referer header on redirect
                                             urllib2.HTTPCookieProcessor(self.cookies))     # keep cookies
 
@@ -88,7 +97,7 @@ class BingRewards:
             self.opener = urllib2.build_opener(
                                             #urllib2.HTTPSHandler(debuglevel = 1),     # be verbose on HTTPS
                                             #urllib2.HTTPHandler(debuglevel = 1),      # be verbose on HTTP
-                                            urllib2.HTTPSHandler(),
+                                            urllib2.HTTPSHandler(context=ctx),
                                             HTTPRefererHandler,                       # add Referer header on redirect
                                             urllib2.HTTPCookieProcessor(self.cookies))     # keep cookies
 

--- a/pkg/config.py
+++ b/pkg/config.py
@@ -57,6 +57,7 @@ class Config:
             self.addSearchesDesktopSalt  = 0      # default to this number of additional Desktop searches for salt
             self.addSearchesMobile       = 0      # default to this number of additional Mobile searches
             self.addSearchesMobileSalt   = 0      # default to this number of additional Mobile searches for salt
+            self.ignoreSSLErrors         = 0      # don't ignore SSL errors by default ("0"), set to "1" to ignore them
 
     class Proxy:
         """
@@ -426,6 +427,7 @@ class Config:
         g.addSearchesMobileSalt   = self.__parseIntAttr(xmlGeneralNode,   "addSearchesMobileSalt",   g.addSearchesMobileSalt,   "general.addSearchesMobileSalt")
         g.addSearchesDesktop      = self.__parseIntAttr(xmlGeneralNode,   "addSearchesDesktop",      g.addSearchesDesktop,      "general.addSearchesDesktop")
         g.addSearchesDesktopSalt  = self.__parseIntAttr(xmlGeneralNode,   "addSearchesDesktopSalt",  g.addSearchesDesktopSalt,  "general.addSearchesDesktopSalt")
+        g.ignoreSSLErrors         = self.__parseIntAttr(xmlGeneralNode,   "ignoreSSLErrors",         g.ignoreSSLErrors,         "general.ignoreSSLErrors")
 
         self.general = g
 

--- a/test/ut_config.py
+++ b/test/ut_config.py
@@ -21,7 +21,8 @@ class UTConfig(unittest.TestCase):
         betweenQueriesInterval="12.271"
         betweenQueriesSalt="5.7"
         betweenAccountsInterval="404.1"
-        betweenAccountsSalt="40.52" />
+        betweenAccountsSalt="40.52"
+        ignoreSSLErrors="7" />
 
     <accounts>
         <account type="Facebook" disabled="false">
@@ -132,6 +133,7 @@ class UTConfig(unittest.TestCase):
         self.assertEqual(self.config.general.betweenQueriesSalt, 5.7)
         self.assertEqual(self.config.general.betweenAccountsInterval, 404.1)
         self.assertEqual(self.config.general.betweenAccountsSalt, 40.52)
+        self.assertEqual(self.config.general.ignoreSSLErrors, 7)
 
     def test_event_parse_populatesConfigCorrectly(self):
         self.__checkGeneral()

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,6 @@
-Current version 3.16.9
+Current version 3.16.10
+
+3.16.10  *) @specu, Added a config option ignoreSSLErrors, self-explanatory, default is "0" (for "false", set to "1" for "true")
 
 3.16.9  *) @specu, Catch exception trying to open 'ms-rewards' and other unsupported URLs
 


### PR DESCRIPTION
Added a config option ignoreSSLErrors, self-explanatory, default is "0" (for "false", set to "1" for "true")

This is for when SSL errors are happening, mostly due to network environment the script is run in for situations where ability to run the script successfully is more important than the security of the network traffic. Obviously not recommended but a good option to have.